### PR TITLE
ENH: cleans up metadata handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,18 @@
 run:
 	replay provenance \
 	--i-in-fp provenance_lib/tests/data/v5_uu_emperor.qzv \
+	--p-use-recorded-metadata \
 	--p-verbose \
+	--o-metadata-out-fp './gerbils-time' \
 	--o-out-fp ./replay_scripts/sample_replay.sh
 
 run-py:
 	replay provenance \
 	--i-in-fp provenance_lib/tests/data/v5_uu_emperor.qzv \
 	--p-usage-driver python3 \
+	--p-use-recorded-metadata \
 	--p-verbose \
+	--o-metadata-out-fp './gerbils-time' \
 	--o-out-fp ./replay_scripts/sample_replay.py
 
 run-cite:

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -204,10 +204,10 @@ class ReplayPythonUsageVariable(ArtifactAPIUsageVariable):
             # No format here - it shouldn't be possible to make it this far
         }[self.var_type]
         var_name = '_'.join(parts)
-        # NOTE: This will no longer guarantee valid python identifiers,
-        # because it allows <>. We get more human-readable no-prov node names.
-        # Alternately, we could replace < and > with e.g. ___, which is
-        # unlikely to occur and is still a valid python identifier
+        # NOTE: unlike the parent method, this does not guarantee valid python
+        # identifiers, because it allows <>. We get more human-readable no-prov
+        # node names. Alternately, we could replace < and > with e.g. ___,
+        # which is unlikely to occur and is still a valid python identifier
         var_name = re.sub(r'[^a-zA-Z0-9_<>]|^(?=\d)', '_', var_name)
         return self.repr_raw_variable_name(var_name)
 

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -327,7 +327,7 @@ class ReplayPythonUsage(ArtifactAPIUsage):
         self._update_imports(from_='qiime2', import_='Metadata')
         input_fp = var.to_interface_name()
         if dumped_md_fn:
-            lines = [f'{input_fp} = Metadata.load(\'{dumped_md_fn}\')']
+            lines = [f'{input_fp} = Metadata.load(\'{dumped_md_fn}.tsv\')']
         else:
             self.comment(
                 'NOTE: You may substitute already-loaded Metadata for the '

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -544,6 +544,19 @@ class ReplayCLIUsage(CLIUsage):
 
         return imported_var
 
+    def init_metadata(self, name, factory, dumped_md_fn: str = ''):
+        """
+        Like parent, but optionally handles file prefixes for recorded md fps
+        """
+        variable = super().init_metadata(name, factory)
+
+        self.init_data.append(variable)
+
+        if dumped_md_fn:
+            variable.name = dumped_md_fn
+
+        return variable
+
     def comment(self, text):
         """
         Identical to parent, but pads comments with an extra newline

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -315,18 +315,26 @@ class ReplayPythonUsage(ArtifactAPIUsage):
 
         return ', '.join(output_vars).strip()
 
-    def init_metadata(self, name, factory):
+    def init_metadata(self, name, factory, dumped_md_fn: str = ''):
         """
         ArtifactAPIUsage doesn't render Metadata loading, so we do it here.
+
+        dumped_md_fn is an optional parameter used only by
+        init_md_from_recorded_md. It allows us to produce scripts that pass
+        metadata dumped from provenance to dumped_md_fn
         """
         var = super().init_metadata(name, factory)
         self._update_imports(from_='qiime2', import_='Metadata')
         input_fp = var.to_interface_name()
-        self.comment(
-            'NOTE: You may substitute already-loaded Metadata for the '
-            'following, or cast a pandas.DataFrame to Metadata as needed.'
-        )
-        lines = [f'{input_fp} = Metadata.load(<your metadata filepath>)']
+        if not dumped_md_fn:
+            self.comment(
+                'NOTE: You may substitute already-loaded Metadata for the '
+                'following, or cast a pandas.DataFrame to Metadata as needed.'
+            )
+            lines = [f'{input_fp} = Metadata.load(<your metadata filepath>)']
+        else:
+            lines = [f'{input_fp} = Metadata.load(\'{dumped_md_fn}\')']
+
         self._add(lines)
         return var
 

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -456,6 +456,18 @@ class ReplayPythonUsage(ArtifactAPIUsage):
 
 
 class ReplayCLIUsageVariable(CLIUsageVariable):
+    EXT = {
+        'artifact': '.qza',
+        'visualization': '.qzv',
+        'metadata': '',
+        'column': '',
+        'format': '',
+    }
+
+    @property
+    def ext(self):
+        return self.EXT[self.var_type]
+
     def to_interface_name(self):
         """
         Like parent, but does not kebab-case metadata. Filepaths are preserved.
@@ -528,9 +540,9 @@ class ReplayCLIUsage(CLIUsage):
     def _make_param(self, value, state):
         """ wrap metadata filenames in <> to force users to replace them """
         if state['metadata'] == 'column':
-            value = (f'<{value[0]}>', *value[1:])
+            value = (f'{value[0]}', *value[1:])
         if state['metadata'] == 'file':
-            value = f'<{value}>'
+            value = f'{value}'
         return super()._make_param(value, state)
 
     def import_from_format(self, name, semantic_type, variable,
@@ -574,7 +586,9 @@ class ReplayCLIUsage(CLIUsage):
         self.init_data.append(variable)
 
         if dumped_md_fn:
-            variable.name = dumped_md_fn
+            variable.name = f'"{dumped_md_fn}.tsv"'
+        else:
+            variable.name = '<your metadata filepath>'
 
         return variable
 

--- a/provenance_lib/_usage_drivers.py
+++ b/provenance_lib/_usage_drivers.py
@@ -326,14 +326,14 @@ class ReplayPythonUsage(ArtifactAPIUsage):
         var = super().init_metadata(name, factory)
         self._update_imports(from_='qiime2', import_='Metadata')
         input_fp = var.to_interface_name()
-        if not dumped_md_fn:
+        if dumped_md_fn:
+            lines = [f'{input_fp} = Metadata.load(\'{dumped_md_fn}\')']
+        else:
             self.comment(
                 'NOTE: You may substitute already-loaded Metadata for the '
                 'following, or cast a pandas.DataFrame to Metadata as needed.'
             )
             lines = [f'{input_fp} = Metadata.load(<your metadata filepath>)']
-        else:
-            lines = [f'{input_fp} = Metadata.load(\'{dumped_md_fn}\')']
 
         self._add(lines)
         return var

--- a/provenance_lib/click_commands.py
+++ b/provenance_lib/click_commands.py
@@ -49,6 +49,20 @@ def replay():
               default=True,
               show_default=True,
               help='print status messages to stdout while processing')
+@click.option('--p-dump-recorded-metadata/--p-no-dump-recorded-metadata',
+              default=True,
+              show_default=True,
+              help='write the original metadata captured in provenance to '
+                   'disk in the --o-metadata-out-fp directory')
+@click.option('--o-metadata-out-fp',
+              default='',
+              show_default=True,
+              help=('the directory where captured study metadata '
+                    'should be written if --p-dump-recorded-metadata. This '
+                    'often produces many outputs, so a dedicated directory '
+                    'should generally be used. Creates the directory if it '
+                    'does not already exist. By default, metadata is written '
+                    'to `${PWD}/recorded_metadata/`'))
 @click.option('--o-out-fp',
               required=True,
               help='the filepath where your replay script should be written.')
@@ -59,7 +73,10 @@ def provenance(i_in_fp: FileName, o_out_fp: FileName,
                p_parse_metadata: bool = True,
                p_use_recorded_metadata: bool = False,
                p_suppress_header: bool = False,
-               p_verbose: bool = True):
+               p_verbose: bool = True,
+               p_dump_recorded_metadata: bool = True,
+               o_metadata_out_fp: FileName = '',
+               ):
     """
     Replay provenance from a QIIME 2 Artifact filepath to a written executable
     """
@@ -71,7 +88,9 @@ def provenance(i_in_fp: FileName, o_out_fp: FileName,
                       recursive=p_recurse,
                       use_recorded_metadata=p_use_recorded_metadata,
                       suppress_header=p_suppress_header,
-                      verbose=p_verbose)
+                      verbose=p_verbose,
+                      dump_recorded_metadata=p_dump_recorded_metadata,
+                      md_out_fp=o_metadata_out_fp,)
     filename = os.path.realpath(o_out_fp)
     click.echo(f'Replay script written to {filename}')
 
@@ -159,6 +178,20 @@ def citations(i_in_fp: FileName,
               default=True,
               show_default=True,
               help='print status messages to stdout while processing')
+@click.option('--p-dump-recorded-metadata/--p-no-dump-recorded-metadata',
+              default=True,
+              show_default=True,
+              help='write the original metadata captured in provenance to '
+                   'disk in the --o-metadata-out-fp directory')
+@click.option('--o-metadata-out-fp',
+              default='',
+              show_default=True,
+              help=('the directory where captured study metadata '
+                    'should be written if --p-dump-recorded-metadata. This '
+                    'often produces many outputs, so a dedicated directory '
+                    'should generally be used. Creates the directory if it '
+                    'does not already exist. By default, metadata is written '
+                    'to `${PWD}/recorded_metadata/`'))
 @click.option('--o-out-fp',
               required=True,
               help='the filepath where your reproduciblity supplement zipfile '
@@ -171,7 +204,9 @@ def reproducibility_supplement(i_in_fp: FileName,
                                p_recurse: bool = False,
                                p_deduplicate: bool = True,
                                p_suppress_header: bool = False,
-                               p_verbose: bool = True):
+                               p_verbose: bool = True,
+                               p_dump_recorded_metadata: bool = True,
+                               o_metadata_out_fp: FileName = '',):
     """
     Produces a zipfile package of useful documentation for enabling in silico
     reproducibility of some QIIME 2 Result(s) from a QIIME 2 Artifact or
@@ -190,4 +225,6 @@ def reproducibility_supplement(i_in_fp: FileName,
         recurse=p_recurse,
         deduplicate=p_deduplicate,
         suppress_header=p_suppress_header,
-        verbose=p_verbose)
+        verbose=p_verbose,
+        dump_recorded_metadata=p_dump_recorded_metadata,
+        md_out_fp=o_metadata_out_fp,)

--- a/provenance_lib/click_commands.py
+++ b/provenance_lib/click_commands.py
@@ -35,12 +35,12 @@ def replay():
 @click.option('--p-parse-metadata/--p-no-parse-metadata',
               default=True,
               show_default=True,
-              help=('parse the original metadata captured by provenance '
+              help=('parse the original metadata captured in provenance '
                     'for review or replay'))
 @click.option('--p-use-recorded-metadata/--p-no-use-recorded-metadata',
               default=False,
               show_default=True,
-              help='re-use the original metadata captured by provenance')
+              help='re-use the original metadata captured in provenance')
 @click.option('--p-suppress-header/--p-no-suppress-header',
               default=False,
               show_default=True,
@@ -164,12 +164,12 @@ def citations(i_in_fp: FileName,
 @click.option('--p-parse-metadata/--p-no-parse-metadata',
               default=True,
               show_default=True,
-              help=('parse the original metadata captured by provenance '
+              help=('parse the original metadata captured in provenance '
                     'for review or replay'))
 @click.option('--p-use-recorded-metadata/--p-no-use-recorded-metadata',
               default=False,
               show_default=True,
-              help='re-use the original metadata captured by provenance')
+              help='re-use the original metadata captured in provenance')
 @click.option('--p-suppress-header/--p-no-suppress-header',
               default=False,
               show_default=True,

--- a/provenance_lib/click_commands.py
+++ b/provenance_lib/click_commands.py
@@ -182,16 +182,7 @@ def citations(i_in_fp: FileName,
               default=True,
               show_default=True,
               help='write the original metadata captured in provenance to '
-                   'disk in the --o-metadata-out-fp directory')
-@click.option('--o-metadata-out-fp',
-              default='',
-              show_default=True,
-              help=('the directory where captured study metadata '
-                    'should be written if --p-dump-recorded-metadata. This '
-                    'often produces many outputs, so a dedicated directory '
-                    'should generally be used. Creates the directory if it '
-                    'does not already exist. By default, metadata is written '
-                    'to `${PWD}/recorded_metadata/`'))
+                   'disk in the --o-out-fp archive')
 @click.option('--o-out-fp',
               required=True,
               help='the filepath where your reproduciblity supplement zipfile '
@@ -206,7 +197,7 @@ def reproducibility_supplement(i_in_fp: FileName,
                                p_suppress_header: bool = False,
                                p_verbose: bool = True,
                                p_dump_recorded_metadata: bool = True,
-                               o_metadata_out_fp: FileName = '',):
+                               ):
     """
     Produces a zipfile package of useful documentation for enabling in silico
     reproducibility of some QIIME 2 Result(s) from a QIIME 2 Artifact or
@@ -227,4 +218,4 @@ def reproducibility_supplement(i_in_fp: FileName,
         suppress_header=p_suppress_header,
         verbose=p_verbose,
         dump_recorded_metadata=p_dump_recorded_metadata,
-        md_out_fp=o_metadata_out_fp,)
+        )

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -396,13 +396,15 @@ def build_action_usage(node: ProvNode,
             unique_md_id = ns.usg_var_namespace[node._uuid] + '_' + param_name
             ns.usg_var_namespace.update(
                 {unique_md_id: camel_to_snake(param_name)})
-            md_fn = ns.usg_var_namespace[unique_md_id] + '.tsv'
+            md_fn = ns.usg_var_namespace[unique_md_id]
             # TODO: When no_parse_metadata, we're still calling this
             # which raises an error. We shouldn't be dumping md if we're not
             # parsing it. This should be safe now, but needs testing
             if cfg.dump_recorded_metadata:
+                md_with_ext = md_fn + '.tsv'
                 dump_recorded_md_file(
-                    cfg, node, plg_action_name, param_name, md_fn)
+                    cfg, node, plg_action_name, param_name, md_with_ext
+                )
 
             if cfg.use_recorded_metadata:
                 # the local dir and fp where md will be saved (if at all) is:

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -452,8 +452,7 @@ def build_action_usage(node: ProvNode,
 
 def init_md_from_recorded_md(node: ProvNode, param_name: str, md_id: str,
                              ns: UsageVarsDict, cfg: ReplayConfig,
-                             md_fn: FileName) -> \
-                                 UsageVariable:
+                             md_fn: FileName) -> UsageVariable:
     """
     initializes and returns a Metadata UsageVariable with Metadata scraped
     and dumped to disk from provenance

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -460,6 +460,9 @@ def init_md_from_recorded_md(node: ProvNode, param_name: str, md_id: str,
     initializes and returns a Metadata UsageVariable with Metadata scraped
     and dumped to disk from provenance
 
+    Assumes it will not be called if no metadata has been dumped to disk.
+    This is enforced above in replay_provenance for faster failure
+
     Raises a ValueError if the node has no metadata
     """
     if not node.metadata:

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -735,7 +735,7 @@ def write_reproducibility_supplement(payload: Union[FileName, ProvDAG],
                                      suppress_header: bool = False,
                                      verbose: bool = True,
                                      dump_recorded_metadata: bool = False,
-                                     md_out_fp: FileName = '',):
+                                     ):
     """
     Produces a zipfile package of useful documentation for enabling in silico
     reproducibility of some QIIME 2 Result(s) from a ProvDAG, a QIIME 2
@@ -765,8 +765,9 @@ def write_reproducibility_supplement(payload: Union[FileName, ProvDAG],
         }
 
         for usage_driver in DRIVER_NAMES:
+            md_out_fp = tmpdir_path / 'recorded_metadata'
             rel_fp = filenames[usage_driver]
-            tmp_fp = pathlib.Path(tmpdir_path) / rel_fp
+            tmp_fp = tmpdir_path / rel_fp
             replay_provenance(
                 payload=dag,
                 out_fp=str(tmp_fp),

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -200,7 +200,7 @@ def replay_provenance(payload: Union[FileName, ProvDAG],
             "disk. Re-run with dump-recorded-metadata set to True, or "
             "use-recorded-metadata set to False. Possible future support for "
             "'touchless' replay from provenance is tracked in "
-            "https://github.com/qiime2/provenance-lib/issues/63")
+            "https://github.com/qiime2/provenance-lib/issues/98")
 
     # The ProvDAGParser handles ProvDAGs quickly, so we can just throw whatever
     # payload we get at this instead of maintaining per-data-type functions
@@ -767,7 +767,7 @@ def write_reproducibility_supplement(payload: Union[FileName, ProvDAG],
                                      deduplicate: bool = True,
                                      suppress_header: bool = False,
                                      verbose: bool = True,
-                                     dump_recorded_metadata: bool = False,
+                                     dump_recorded_metadata: bool = True,
                                      ):
     """
     Produces a zipfile package of useful documentation for enabling in silico
@@ -810,8 +810,6 @@ def write_reproducibility_supplement(payload: Union[FileName, ProvDAG],
                 verbose=verbose,
                 dump_recorded_metadata=dump_recorded_metadata,
                 md_out_fp=md_out_fp)
-            # don't duplicate captured metadata .tsvs files
-            dump_recorded_metadata = False
             print(f'{usage_driver} replay script written to {rel_fp}')
 
         tmp_fp = tmpdir_path / 'citations.bib'

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -397,9 +397,6 @@ def build_action_usage(node: ProvNode,
             ns.usg_var_namespace.update(
                 {unique_md_id: camel_to_snake(param_name)})
             md_fn = ns.usg_var_namespace[unique_md_id]
-            # TODO: When no_parse_metadata, we're still calling this
-            # which raises an error. We shouldn't be dumping md if we're not
-            # parsing it. This should be safe now, but needs testing
             if cfg.dump_recorded_metadata:
                 md_with_ext = md_fn + '.tsv'
                 dump_recorded_md_file(
@@ -424,8 +421,11 @@ def build_action_usage(node: ProvNode,
                         "to enable visual inspection.")
 
                 if not command_specific_md_context_has_been_printed:
-                    # TODO: This needs to be a custom fp
-                    fp = f'recorded_metadata/{plg_action_name}/'
+                    if cfg.md_out_fp:
+                        fp = f'{cfg.md_out_fp}/{plg_action_name}'
+                    else:
+                        fp = f'./recorded_metadata/{plg_action_name}/'
+
                     cfg.use.comment(
                         "The following command may have received additional "
                         "metadata .tsv files. To confirm you have covered "

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -455,7 +455,7 @@ def init_md_from_recorded_md(node: ProvNode, param_name: str, md_id: str,
                              md_fn: FileName) -> \
                                  UsageVariable:
     """
-    initializes and returns a Metadata UsageVariable with Metadata scraped 
+    initializes and returns a Metadata UsageVariable with Metadata scraped
     and dumped to disk from provenance
 
     Raises a ValueError if the node has no metadata

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -39,11 +39,9 @@ class ReplayConfig():
     - pm
       an instance of the QIIME 2 PluginManager
     - md_context_has_been_printed
-      TODO: if this was no_md_context, True would prevent context from printing
       a flag set by default and used internally, allows context to be printed
       once and only once.
     - no_provenance_context_has_been_printed
-      TODO: if this was no_no_pr_context, True would stop context from printing
       indicates the no-provenance context documentation has not been printed
     - header
       if True, an introductory how-to header should be rendered to the script
@@ -554,10 +552,9 @@ def dump_recorded_md_file(cfg: ReplayConfig, node: ProvNode, action_name: str,
 
     Raises a ValueError if the node has no metadata
     """
-    # TODO: node.metadata will also be None if no-parse-metadata is passed.
-    # Fix that!
-
-    # The problem above is probably an unreachable case now, but needs testing
+    # NOTE: node.metadata will also be None if no-parse-metadata is passed,
+    # which would error unpredictably if the check preventing md dumping with
+    # no-parse-provenance was removed from replay_provenance
     if node.metadata is None:
         raise ValueError(
             'This function should only be called if the node has metadata.')

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -193,7 +193,7 @@ def replay_provenance(payload: Union[FileName, ProvDAG],
 
     if use_recorded_metadata and not dump_recorded_metadata:
         raise NotImplementedError(
-            "In order to produce a replay script from that uses metadata "
+            "In order to produce a replay script that uses metadata "
             "captured in provenance, that metadata must first be written to "
             "disk. Re-run with dump-recorded-metadata set to True, or "
             "use-recorded-metadata set to False. Possible future support for "

--- a/provenance_lib/replay.py
+++ b/provenance_lib/replay.py
@@ -258,6 +258,7 @@ def build_usage_examples(dag: ProvDAG, cfg: ReplayConfig):
         build_no_provenance_node_usage(n_data, node_id, usg_ns, cfg)
 
     for action_id in (std_actions := actions.std_actions):
+        # We are replaying actions not nodes, so any associated node works
         some_node_id_from_this_action = next(iter(std_actions[action_id]))
         n_data = dag.get_node_data(some_node_id_from_this_action)
         if n_data.action.action_type == 'import':

--- a/provenance_lib/tests/test_click_commands.py
+++ b/provenance_lib/tests/test_click_commands.py
@@ -220,7 +220,36 @@ class ReproducibilitySupplementTests(CustomAssertions):
             exp = {'python3_replay.py',
                    'cli_replay.sh',
                    'citations.bib',
+                   'recorded_metadata/',
+                   'recorded_metadata/demux_emp_single_0/',
+                   ('recorded_metadata/diversity_core_metrics_phylogenetic_0/'
+                    'metadata_0.tsv'),
+                   'recorded_metadata/diversity_core_metrics_phylogenetic_0/',
+                   'recorded_metadata/demux_emp_single_0/barcodes_0.tsv',
                    }
 
             with zipfile.ZipFile(out_fp, 'r') as myzip:
                 self.assertEqual(exp, set(myzip.namelist()))
+
+    def test_write_reproducibility_supplement_no_metadata_dump(self):
+        """
+        Confirms that metadata dumping does not occur when user opts out
+        """
+        in_fp = TEST_DATA['5']['qzv_fp']
+        in_fn = str(in_fp)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_fp = pathlib.Path(tmpdir) / 'supplement.zip'
+            out_fn = str(out_fp)
+            res = CliRunner().invoke(
+                cli=reproducibility_supplement,
+                args=(f"--i-in-fp {in_fn} --o-out-fp {out_fn} "
+                      "--p-no-dump-recorded-metadata"))
+
+            self.assertEqual(res.exit_code, 0)
+            self.assertTrue(out_fp.is_file())
+            self.assertTrue(zipfile.is_zipfile(out_fp))
+
+            exp = 'recorded_metadata/'
+
+            with zipfile.ZipFile(out_fp, 'r') as myzip:
+                self.assertNotIn(exp, set(myzip.namelist()))

--- a/provenance_lib/tests/test_replay.py
+++ b/provenance_lib/tests/test_replay.py
@@ -145,6 +145,15 @@ class ReplayProvenanceTests(unittest.TestCase):
                 dump_recorded_metadata=False,
                 md_out_fp='/user/dumb/some_filepath')
 
+    def test_replay_use_md_without_dump_md(self):
+        in_fp = TEST_DATA['5']['qzv_fp']
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "(?s)uses.*metadata.*must.*written to disk"):
+            replay_provenance(
+                in_fp, 'unused_fp', 'python3', use_recorded_metadata=True,
+                dump_recorded_metadata=False)
+
     def test_replay_from_provdag(self):
         v5_dag = ProvDAG(TEST_DATA['5']['qzv_fp'])
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/provenance_lib/tests/test_replay.py
+++ b/provenance_lib/tests/test_replay.py
@@ -648,6 +648,31 @@ class InitializerTests(unittest.TestCase):
                r"recorded_metadata/demux_emp_single_0/barcodes_0.tsv'")
         self.assertRegex(rendered, exp)
 
+    def test_init_md_from_recorded_md_user_passed_fp(self):
+        has_md_id = '99fa3670-aa1a-45f6-ba8e-803c976a1163'
+        dag = ProvDAG(os.path.join(DATA_DIR, 'v5_table.qza'))
+        md_node = dag.get_node_data(has_md_id)
+
+        var_nm = 'per_sample_sequences_0_barcodes'
+        param_nm = 'barcodes'
+        # the variable name should already be added to the namespace
+        ns = UsageVarsDict({var_nm: param_nm})
+        cfg = ReplayConfig(use=SUPPORTED_USAGE_DRIVERS['python3'](),
+                           use_recorded_metadata=False, pm=pm,
+                           md_out_fp='./md_out')
+        md_fn = 'test_a/test_o'
+
+        var = init_md_from_recorded_md(
+            md_node, param_nm, var_nm, ns, cfg, md_fn)
+        self.assertIsInstance(var, UsageVariable)
+        self.assertEqual(var.var_type, 'column')
+
+        rendered = cfg.use.render()
+        print(rendered)
+        self.assertRegex(rendered, 'from qiime2 import Metadata')
+        exp = (r"barcodes_0_md = Metadata.load\('.*md_out/test_a/test_o.tsv'")
+        self.assertRegex(rendered, exp)
+
     def test_init_md_from_artifacts_no_artifacts(self):
         cfg = ReplayConfig(use=SUPPORTED_USAGE_DRIVERS['python3'](),
                            use_recorded_metadata=False, pm=pm)

--- a/provenance_lib/tests/test_replay.py
+++ b/provenance_lib/tests/test_replay.py
@@ -935,7 +935,7 @@ class BuildActionUsageTests(CustomAssertions):
         pcoa_id = '9f6a0f3e-22e6-4c39-8733-4e672919bbc7'
         n_id = '0b8b47bd-f2f8-4029-923c-0e37a68340c3'
         cfg = ReplayConfig(use=SUPPORTED_USAGE_DRIVERS['cli'](),
-                           use_recorded_metadata=True, pm=pm)
+                           use_recorded_metadata=False, pm=pm)
         ns = NamespaceCollections()
         import_var = CLIUsageVariable(
             'pcoa', lambda: None, 'artifact', cfg.use)

--- a/provenance_lib/tests/test_replay.py
+++ b/provenance_lib/tests/test_replay.py
@@ -428,7 +428,6 @@ class MiscHelperFnTests(unittest.TestCase):
     def test_param_is_metadata_col(self):
         """
         Assumes q2-demux and q2-diversity are installed in the active env.
-        TODO: replace with dummy plugin if we integrate this into the framework
         """
         cfg = ReplayConfig(use=SUPPORTED_USAGE_DRIVERS['cli'](),
                            use_recorded_metadata=False, pm=pm)

--- a/provenance_lib/tests/test_usage_drivers.py
+++ b/provenance_lib/tests/test_usage_drivers.py
@@ -3,9 +3,25 @@ import pathlib
 import tempfile
 import unittest
 
+from qiime2.sdk.usage import UsageAction
+
 from ..replay import replay_provenance
 from .test_parse import DATA_DIR
-from .._usage_drivers import MissingPluginError
+from .._usage_drivers import MissingPluginError, _get_action_if_plugin_present
+
+
+class MiscHelperFunctionTests(unittest.TestCase):
+    def test_get_action_if_plugin_present_plugin_present(self):
+        real_action = UsageAction('diversity', 'core_metrics')
+        action = _get_action_if_plugin_present(real_action)
+        self.assertEqual('diversity', action.plugin_id)
+        self.assertEqual('core_metrics', action.id)
+
+    def test_get_action_if_plugin_present_plugin_missing(self):
+        fake_action = UsageAction('imaginary', 'action')
+        with self.assertRaisesRegex(
+                MissingPluginError, "(?s)missing one or more plugins.*library"):
+            _get_action_if_plugin_present(fake_action)
 
 
 class ReplayPythonUsageTests(unittest.TestCase):

--- a/provenance_lib/tests/test_usage_drivers.py
+++ b/provenance_lib/tests/test_usage_drivers.py
@@ -7,7 +7,9 @@ from qiime2.sdk.usage import UsageAction
 
 from ..replay import replay_provenance
 from .test_parse import DATA_DIR
-from .._usage_drivers import MissingPluginError, _get_action_if_plugin_present
+from .._usage_drivers import (
+    MissingPluginError, ReplayCLIUsage, _get_action_if_plugin_present,
+)
 
 
 class MiscHelperFunctionTests(unittest.TestCase):
@@ -20,8 +22,25 @@ class MiscHelperFunctionTests(unittest.TestCase):
     def test_get_action_if_plugin_present_plugin_missing(self):
         fake_action = UsageAction('imaginary', 'action')
         with self.assertRaisesRegex(
-                MissingPluginError, "(?s)missing one or more plugins.*library"):
+                MissingPluginError,
+                "(?s)missing one or more plugins.*library"):
             _get_action_if_plugin_present(fake_action)
+
+
+class ReplayCLIUsageTests(unittest.TestCase):
+    def test_init_metadata(self):
+        use = ReplayCLIUsage()
+        var = use.init_metadata(name='testing', factory=lambda: None)
+        print(var)
+        self.assertEqual(var.name, '<your metadata filepath>')
+        self.assertEqual(var.var_type, 'metadata')
+
+    def test_init_metadata_with_dumped_md_fn(self):
+        use = ReplayCLIUsage()
+        var = use.init_metadata(
+            name='testing', factory=lambda: None, dumped_md_fn='some_md')
+        self.assertEqual(var.var_type, 'metadata')
+        self.assertEqual(var.name, '"some_md.tsv"')
 
 
 class ReplayPythonUsageTests(unittest.TestCase):


### PR DESCRIPTION
closes #57, making metadata outputs optional
closes #63, providing a hands-on (script-based) approach to replay from captured metadata